### PR TITLE
Fixed markdown, added docu, added resource for uptime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,34 @@
-##A 9 kB WAR Ping For JavaEE 7 Application Servers
+# Tiny Ping For JavaEE 7 Application Servers
 
-Ping exposes via a convenient URI basic health / jndi / jvm and OS information.
+Ping exposes basic health, JNDI, JVM and OS metrics via a convenient URI, 
+which enables an easy integration into application monitoring solutions
+and smoke tests. The whole WAR file is only a couple of kilobytes in size.
 
-Tested with GlassFish, Payara, TomEE, WLP and Wildfly
+Tested with GlassFish, Payara, TomEE, WebSphere Liberty and Wildfly.
 
-###Installation:
+## Features:
+
+  * Echo Resource `/resources/pings/echo/{message}`
+  * List system properties `/resources/pings/system-properties`
+  * List environment variables `/resources/pings/environment-variables` 
+  * List java: namespace `/resources/pings/jndi/java:`
+  * List java:comp/env namespace `/resources/pings/jndi/java:comp/env`
+  * List jave:global namespace `/resources/pings/jndi/java:global`
+  * Start boot time `/resources/health/start-time`
+  * Uptime in milliseconds `/resources/health/uptime`
+  * Current memory stats `/resources/health/current-memory`
+  * Operating system stats `/resources/health/os-info`
+
+## Installation:
 
 Drop the WAR https://github.com/AdamBien/ping/releases/ into your autodeploy folder and access the application with http://localhost:[YOUR_PORT]/ping
+
+## Build:
+
+Ping can be built with Maven like this:
+
+    mvn clean package
+
+Your WAR file will be written to the following directory:
+
+    target/ping.war

--- a/src/main/java/com/airhacks/ping/boundary/HealthResource.java
+++ b/src/main/java/com/airhacks/ping/boundary/HealthResource.java
@@ -1,6 +1,8 @@
 package com.airhacks.ping.boundary;
 
 import com.airhacks.ping.control.ServerWatch;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import javax.inject.Inject;
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -28,6 +30,13 @@ public class HealthResource {
         return this.watch.getDateTime().toString();
     }
 
+    @GET
+    @Path("/uptime")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String uptime() {
+        return Long.toString(ChronoUnit.MILLIS.between(this.watch.getDateTime(), ZonedDateTime.now()));
+    }
+    
     @GET
     @Path("/current-memory")
     public JsonObject availableHeap() {

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -36,6 +36,9 @@
                 <a href="./resources/health/start-time">Start (boot) time</a>
             </article>
             <article>
+                <a href="./resources/health/uptime">Uptime in milliseconds</a>
+            </article>
+            <article>
                 <a href="./resources/health/current-memory">Current memory stats</a>
             </article>
             <article>


### PR DESCRIPTION
Hi Adam, I would propose the following changes, feel free to integrate or reject them...

  * I fixed the markdown formatting and listed the available resources.
  * A handy uptime resource that (obviously) states the uptime in milliseconds since the app start. This can be used to calculate the average uptime in external tools easily, without having to deal with date calculations (and possibly time zones).

Downside: the WAR size is now 12 kB instead of only 9kB ;-)